### PR TITLE
Nicer branding

### DIFF
--- a/nulinks-common/src/data.js
+++ b/nulinks-common/src/data.js
@@ -814,12 +814,26 @@ const NULINKS_DATA = [
     usageFrequency: "ONCE"
   },
   {
-    keywords: ["nulinks", "extension", "nulinks-extension"],
-    title: "NULinks",
+    keywords: ["parkour-president", "aoun-runs"],
+    title: "Parkour President",
+    target: "https://www.youtube.com/watch?v=Q2Q3V2Dky6Q",
+    description: "Joseph E. Aoun almost missing his 2019 Commencement Speech",
+    usageFrequency: "ONCE"
+  },
+  {
+    keywords: ["nulinks-extension"],
+    title: "NULinks Chrome Extension",
     target:
       "https://chrome.google.com/webstore/detail/nulinks/gfbdcgkehhkgfehdilpmldkeihiojjak",
-    description: "The NULinks chrome extension. Unofficial and run by students",
+    description: "The NULinks Chrome Extension. Unofficial and run by students",
     usageFrequency: "ONCE"
+  },
+  {
+    keywords: ["nulinks", "nulinks-site"],
+    title: "NULinks Site",
+    target: "https://nulinks.kj800x.com",
+    description: "The NULinks website. Unofficial and run by students",
+    usageFrequency: "ONCE A SEMESTER"
   },
   {
     keywords: [

--- a/nulinks-extension/manifest.json
+++ b/nulinks-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "NULinks",
   "version": "0.3.10",
-  "description": "Never need to use MyNEU again!",
+  "description": "MyNortheastern but faster!",
   "icons": {
     "16": "icons/16.png",
     "32": "icons/32.png",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nulinks",
   "version": "0.0.1",
   "private": true,
-  "description": "Never need to use MyNEU again!",
+  "description": "MyNortheastern but faster!",
   "scripts": {
     "install": "cd nulinks-site && npm install && cd ../nulinks-common && npm install",
     "test": "cd nulinks-common && ./node_modules/.bin/jest",


### PR DESCRIPTION
Closes #17 

* `package.json` and `manifest.json`:
Replaces the tagline `Never need to use MyNEU again` with `MyNortheastern but faster`, which seems like a slightly better tagline. At least it doesn't set us in direct opposition with MyNortheastern, just really focusing on how we shine, our speed.

* `data.js`:
Added a link for the hosted site (https://nulinks.kj800x.com) and added a fun link for the parkour president.