### PR TITLE
Microsoft Office and Final Exam Links

### DIFF
--- a/nulinks-common/src/data.js
+++ b/nulinks-common/src/data.js
@@ -207,8 +207,15 @@ const NULINKS_DATA = [
     ],
     title: "On The Hub",
     target: "http://neu.onthehub.com/",
-    description: "Free and Discounted Software for your computer",
+    description: "Free and Discounted Software for your computer (but not Microsoft Office)",
     usageFrequency: "ONCE A SEMESTER"
+  },
+  {
+    keywords: ["microsoft-office", "office", "office-365", "word", "powerpoint", "excel", "onedrive", "sharepoint", "teams", "sway"],
+    title: "Microsoft Office 365",
+    target: "https://sts.northeastern.edu/adfs/ls/?wa=wsignin1.0&wtrealm=urn:federation:MicrosoftOnline&wctx=wa%3Dwsignin1.0%26rpsnv%3D3%26ver%3D6.4.6456.0%26wp%3DMCMBI%26wreply%3Dhttps:%252F%252Fportal.office.com%252Flanding.aspx%253Ftarget%253D%25252fOLS%25252fMySoftware.aspx%26lc%3D1033%26id%3D501392",
+    description: "Access Word, PowerPoint, Excel and others. Sign in with your husky account but use @northeastern.edu instead of @husky.neu.edu",
+    usageFrequency: "A FEW TIMES A WEEK"
   },
   {
     keywords: ["drc", "drc-services"],
@@ -460,6 +467,7 @@ const NULINKS_DATA = [
       "class",
       "class",
       "class",
+      "final-exam-schedule",
       "my-schedule"
     ],
     title: "My Schedule",
@@ -467,6 +475,13 @@ const NULINKS_DATA = [
       "https://nubanner.neu.edu/ssomanager/c/SSB?pkg=bwskfshd.P_CrseSchdDetl",
     description: "View your schedule of classes by term",
     usageFrequency: "A FEW TIMES A SEMESTER"
+  },
+  {
+    keywords: ["final-exam-conflict", "final-exam-conflict-form"],
+    title: "Final Exam Registrar Website",
+    target: "https://registrar.northeastern.edu/article/final-exams/",
+    description: "Access Final Exam Conflict information including the conflict form",
+    usageFrequency: "ONCE A SEMESTER",
   },
   {
     keywords: ["searchneu", "searchnu", "search-classes"],

--- a/nulinks-common/src/data.js
+++ b/nulinks-common/src/data.js
@@ -207,14 +207,28 @@ const NULINKS_DATA = [
     ],
     title: "On The Hub",
     target: "http://neu.onthehub.com/",
-    description: "Free and Discounted Software for your computer (but not Microsoft Office)",
+    description:
+      "Free and Discounted Software for your computer (but not Microsoft Office)",
     usageFrequency: "ONCE A SEMESTER"
   },
   {
-    keywords: ["microsoft-office", "office", "office-365", "word", "powerpoint", "excel", "onedrive", "sharepoint", "teams", "sway"],
+    keywords: [
+      "microsoft-office",
+      "office",
+      "office-365",
+      "word",
+      "powerpoint",
+      "excel",
+      "onedrive",
+      "sharepoint",
+      "teams",
+      "sway"
+    ],
     title: "Microsoft Office 365",
-    target: "https://sts.northeastern.edu/adfs/ls/?wa=wsignin1.0&wtrealm=urn:federation:MicrosoftOnline&wctx=wa%3Dwsignin1.0%26rpsnv%3D3%26ver%3D6.4.6456.0%26wp%3DMCMBI%26wreply%3Dhttps:%252F%252Fportal.office.com%252Flanding.aspx%253Ftarget%253D%25252fOLS%25252fMySoftware.aspx%26lc%3D1033%26id%3D501392",
-    description: "Access Word, PowerPoint, Excel and others. Sign in with your husky account but use @northeastern.edu instead of @husky.neu.edu",
+    target:
+      "https://sts.northeastern.edu/adfs/ls/?wa=wsignin1.0&wtrealm=urn:federation:MicrosoftOnline&wctx=wa%3Dwsignin1.0%26rpsnv%3D3%26ver%3D6.4.6456.0%26wp%3DMCMBI%26wreply%3Dhttps:%252F%252Fportal.office.com%252Flanding.aspx%253Ftarget%253D%25252fOLS%25252fMySoftware.aspx%26lc%3D1033%26id%3D501392",
+    description:
+      "Access Word, PowerPoint, Excel and others. Sign in with your husky account but use @northeastern.edu instead of @husky.neu.edu",
     usageFrequency: "A FEW TIMES A WEEK"
   },
   {
@@ -480,8 +494,9 @@ const NULINKS_DATA = [
     keywords: ["final-exam-conflict", "final-exam-conflict-form"],
     title: "Final Exam Registrar Website",
     target: "https://registrar.northeastern.edu/article/final-exams/",
-    description: "Access Final Exam Conflict information including the conflict form",
-    usageFrequency: "ONCE A SEMESTER",
+    description:
+      "Access Final Exam Conflict information including the conflict form",
+    usageFrequency: "ONCE A SEMESTER"
   },
   {
     keywords: ["searchneu", "searchnu", "search-classes"],

--- a/nulinks-common/test/__snapshots__/data.search.test.js.snap
+++ b/nulinks-common/test/__snapshots__/data.search.test.js.snap
@@ -32,7 +32,11 @@ exports[`searching data.js matches snapshot for term faf 1`] = `"FAFSA"`;
 
 exports[`searching data.js matches snapshot for term fas 1`] = `"FAFSA"`;
 
-exports[`searching data.js matches snapshot for term fin 1`] = `"My Financial Aid Status"`;
+exports[`searching data.js matches snapshot for term fin 1`] = `"My Schedule"`;
+
+exports[`searching data.js matches snapshot for term final 1`] = `"My Schedule"`;
+
+exports[`searching data.js matches snapshot for term finan 1`] = `"My Financial Aid Status"`;
 
 exports[`searching data.js matches snapshot for term fire 1`] = `"Emergency? Call: 617-373-3333"`;
 
@@ -62,7 +66,7 @@ exports[`searching data.js matches snapshot for term n 1`] = `"NUCareers"`;
 
 exports[`searching data.js matches snapshot for term nuca 1`] = `"NUCareers"`;
 
-exports[`searching data.js matches snapshot for term o 1`] = `"Scholar OneSearch"`;
+exports[`searching data.js matches snapshot for term o 1`] = `"Microsoft Office 365"`;
 
 exports[`searching data.js matches snapshot for term p 1`] = `"Emergency? Call: 617-373-3333"`;
 
@@ -80,13 +84,13 @@ exports[`searching data.js matches snapshot for term s 1`] = `"Service Time Logs
 
 exports[`searching data.js matches snapshot for term sched 1`] = `"My Schedule"`;
 
-exports[`searching data.js matches snapshot for term t 1`] = `"Access XFINITY On-Campus"`;
+exports[`searching data.js matches snapshot for term t 1`] = `"Microsoft Office 365"`;
 
 exports[`searching data.js matches snapshot for term u 1`] = `"myHealth Center (UHCS)"`;
 
 exports[`searching data.js matches snapshot for term v 1`] = `"On The Hub"`;
 
-exports[`searching data.js matches snapshot for term w 1`] = `"Student Employment (workstudy, timesheets)"`;
+exports[`searching data.js matches snapshot for term w 1`] = `"Microsoft Office 365"`;
 
 exports[`searching data.js matches snapshot for term work 1`] = `"Student Employment (workstudy, timesheets)"`;
 

--- a/nulinks-common/test/data.search.test.js
+++ b/nulinks-common/test/data.search.test.js
@@ -15,6 +15,8 @@ const IMPORTANT_SEARCH_TERMS = [
   "audit",
   "coun",
   "fin",
+  "final",
+  "finan",
   "fas", // This one because I can never spell it correctly
   "faf",
   "hours",


### PR DESCRIPTION
Fix #68, clarify that on-the-hub doesn't have Microsoft Office, make My Schedule show up when searching for `final` (since that's where you find final exam time details). Add `final-exam-conflict` to link to the site with the conflict form.