### PR TITLE
Add Student Hub to data

### DIFF
--- a/nulinks-common/src/data.js
+++ b/nulinks-common/src/data.js
@@ -900,6 +900,14 @@ const NULINKS_DATA = [
     description:
       "Repay your Northeastern-serviced Federal Perkins Loans after graduation",
     usageFrequency: "A FEW TIMES A SEMESTER"
+  },
+  {
+    keywords: ["student-hub", "hub"],
+    title: "Student Hub",
+    target: "https://northeastern.sharepoint.com/sites/studenthub",
+    description:
+      "Visit the Student Hub, home to the dynamic scheduling tool, and a highly personalized platform with key class information, applications, resources, and community engagement",
+    usageFrequency: "DAILY"
   }
 ];
 

--- a/nulinks-common/test/__snapshots__/data.search.test.js.snap
+++ b/nulinks-common/test/__snapshots__/data.search.test.js.snap
@@ -80,7 +80,7 @@ exports[`searching data.js matches snapshot for term reg 1`] = `"Course Registra
 
 exports[`searching data.js matches snapshot for term regis 1`] = `"Course Registration"`;
 
-exports[`searching data.js matches snapshot for term s 1`] = `"Service Time Logs"`;
+exports[`searching data.js matches snapshot for term s 1`] = `"Student Hub"`;
 
 exports[`searching data.js matches snapshot for term sched 1`] = `"My Schedule"`;
 


### PR DESCRIPTION
Resolves #84

Adds link for Student Hub with keywords `student-hub` and `hub`. I grabbed the link details and description from MyNortheastern. I'm also guessing that the usageFrequency should be `DAILY` based on what's on the site but happy to change that if we want.